### PR TITLE
OM-80: main contribution improvement, do not display password change …

### DIFF
--- a/src/components/ProfileMainMenu.js
+++ b/src/components/ProfileMainMenu.js
@@ -20,7 +20,6 @@ class ProfileMainMenu extends Component {
 
   render() {
     const { rights, intl, modulesManager } = this.props;
-    console.log(this.isWorker);
     let entries = [
       {
         text: formatMessage(intl, "profile", "menu.myProfile"),

--- a/src/components/ProfileMainMenu.js
+++ b/src/components/ProfileMainMenu.js
@@ -1,6 +1,9 @@
 import React, { Component } from "react";
 import { injectIntl } from "react-intl";
+import { connect } from "react-redux";
+
 import { AccountCircle, Fingerprint, InsertEmoticon } from "@material-ui/icons";
+
 import {
   formatMessage,
   MainMenuContribution,
@@ -10,21 +13,32 @@ import {
 const PROFILE_MAIN_MENU_CONTRIBUTION_KEY = "profile.MainMenu";
 
 class ProfileMainMenu extends Component {
+  constructor(props) {
+    super(props);
+    this.isWorker = props.modulesManager.getConf("fe-insuree", "isWorker", false);
+  }
+
   render() {
+    const { rights, intl, modulesManager } = this.props;
+    console.log(this.isWorker);
     let entries = [
       {
-        text: formatMessage(this.props.intl, "profile", "menu.myProfile"),
+        text: formatMessage(intl, "profile", "menu.myProfile"),
         icon: <InsertEmoticon />,
         route: "/profile/myProfile",
       },
-      {
-        text: formatMessage(this.props.intl, "profile", "menu.changePassword"),
-        icon: <Fingerprint />,
-        route: "/profile/changePassword",
-      },
     ];
+
+    if (!this.isWorker) {
+      entries.push({
+        text: formatMessage(intl, "profile", "menu.changePassword"),
+        icon: <Fingerprint />,
+        route: "/profile/mobile/password",
+      });
+    }
+
     entries.push(
-      ...this.props.modulesManager
+      ...modulesManager
         .getContribs(PROFILE_MAIN_MENU_CONTRIBUTION_KEY)
         .filter((c) => !c.filter || c.filter(rights))
     );
@@ -32,11 +46,16 @@ class ProfileMainMenu extends Component {
     return (
       <MainMenuContribution
         {...this.props}
-        header={formatMessage(this.props.intl, "profile", "mainMenu")}
+        header={formatMessage(intl, "profile", "mainMenu")}
         icon={<AccountCircle />}
         entries={entries}
       />
     );
   }
 }
-export default injectIntl(withModulesManager(ProfileMainMenu));
+
+const mapStateToProps = (state) => ({
+  rights: state.core?.user?.i_user?.rights ?? [],
+});
+
+export default injectIntl(withModulesManager(connect(mapStateToProps)(ProfileMainMenu)));


### PR DESCRIPTION
…route

[OM-80](https://openimis.atlassian.net/browse/OM-80)

[RELATED PR](https://github.com/openimis/openimis-fe-worker_voucher_js/pull/21)

Changes:
- Hide 'Change Password' route if _isWorker_ is true.
- Pass rights to be able to check if user is allowed to enter.

[OM-80]: https://openimis.atlassian.net/browse/OM-80?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ