### PR TITLE
OM-131: change isworker source, do not display change password if isW…

### DIFF
--- a/src/components/ProfileMainMenu.js
+++ b/src/components/ProfileMainMenu.js
@@ -15,7 +15,7 @@ const PROFILE_MAIN_MENU_CONTRIBUTION_KEY = "profile.MainMenu";
 class ProfileMainMenu extends Component {
   constructor(props) {
     super(props);
-    this.isWorker = props.modulesManager.getConf("fe-insuree", "isWorker", false);
+    this.isWorker = props.modulesManager.getConf("fe-core", "isWorker", false);
   }
 
   render() {
@@ -28,21 +28,13 @@ class ProfileMainMenu extends Component {
       },
     ];
 
-    this.isWorker
-      ? entries.push({
-          text: formatMessage(intl, "profile", "menu.changePassword"),
-          icon: <Fingerprint />,
-          route: "/profile/mobile/password",
-        })
-      : entries.push({
-          text: formatMessage(
-            this.props.intl,
-            "profile",
-            "menu.changePassword"
-          ),
-          icon: <Fingerprint />,
-          route: "/profile/changePassword",
-        });
+    if (!this.isWorker) {
+      entries.push({
+        text: formatMessage(intl, "profile", "menu.changePassword"),
+        icon: <Fingerprint />,
+        route: "/profile/changePassword",
+      });
+    }
 
     entries.push(
       ...modulesManager
@@ -65,4 +57,6 @@ const mapStateToProps = (state) => ({
   rights: state.core?.user?.i_user?.rights ?? [],
 });
 
-export default injectIntl(withModulesManager(connect(mapStateToProps)(ProfileMainMenu)));
+export default injectIntl(
+  withModulesManager(connect(mapStateToProps)(ProfileMainMenu))
+);


### PR DESCRIPTION
…orker true

[OM-131](https://openimis.atlassian.net/browse/OM-131)

Changes:
- Change isWorker source from "fe-insuree" to "fe-core" as it is used across multiple modules.
- If isWorker is true, do not show default Change Password page.

[OM-131]: https://openimis.atlassian.net/browse/OM-131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ